### PR TITLE
Make templates sturdier by wrapping values with quotes

### DIFF
--- a/cookie
+++ b/cookie
@@ -395,7 +395,7 @@ function template_engine() {
         evalue="$(eval "echo \"\$${evar}\"")"
         if [[ -z "${evalue}" ]]; then
             read -p "${evar}: " evalue <&5
-            eval "${evar}=${evalue}"
+            eval "${evar}=\"${evalue}\""
         fi
     
         new_contents="$(echo "${new_contents}" | sed "s/{{[ ]*${evar}[ ]*}}/${evalue}/g")"


### PR DESCRIPTION
Allows templates to handle variables with spaces in them, by wrapping
values with quotes. Fixes #24.